### PR TITLE
Add -o option to let users select an output directory

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@
 pakextract is a small tool to extract the contents of 
 a Quake II pak file into the current directory. Usage:
  
- ./pakextract /path/to/pakfile.pak
+ ./pakextract [ -o output_directory ] /path/to/pakfile.pak
 
 Only Quake II paks are supported. Other pak formats may
 work but it's untested and unsupported.


### PR DESCRIPTION
This might not build on Windows because the getopt function is only available on *nix systems, so if Windows compatibility is important then I guess you should deny this pull request.
